### PR TITLE
allow to install from a deb package

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
   repositories:
     "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib"
     "apt" : "https://github.com/puppetlabs/puppetlabs-apt"
+    "wget": "https://github.com/maestrodev/puppet-wget.git"
   symlinks:
     influxdb: "#{source_dir}"
-

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,8 @@ class influxdb::params {
   $service_enabled                              = true
   $conf_template                                = 'influxdb/influxdb.conf.erb'
   $config_file                                  = '/etc/influxdb/influxdb.conf'
+  $install_method                               = 'repo'
+  $package_source                               = undef
 
   $influxdb_stderr_log                          = '/var/log/influxdb/influxd.log'
   $influxdb_stdout_log                          = '/dev/null'

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,5 +1,4 @@
 class influxdb::repo {
-
   case $::osfamily {
     'Debian': {
       class { 'influxdb::repo::apt': }

--- a/manifests/repo/package.pp
+++ b/manifests/repo/package.pp
@@ -1,0 +1,31 @@
+class influxdb::repo::package (
+  $package_source,
+  $version
+  ) {
+  case $::osfamily {
+    'Debian': {
+      wget::fetch { 'influxdb':
+        source      => $package_source,
+        destination => "/tmp/influxdb_${version}.deb"
+      }
+
+      package { 'influxdb':
+        ensure   => present,
+        provider => 'dpkg',
+        source   => "/tmp/influxdb_${version}.deb",
+        require  => Wget::Fetch['influxdb']
+      }
+    }
+    'RedHat': {
+      package { 'influxdb':
+        ensure   => present,
+        provider => 'rpm',
+        source   => $package_source,
+        require  => Wget::Fetch['influxdb']
+      }
+    }
+    default: {
+      fail("${::operatingsystem} not supported")
+    }
+  }
+}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -4,6 +4,8 @@ class influxdb::server (
   $service_enabled                              = $influxdb::params::service_enabled,
   $conf_template                                = $influxdb::params::conf_template,
   $config_file                                  = $influxdb::params::config_file,
+  $install_method                               = $influxdb::params::install_method,
+  $package_source                               = $influxdb::params::package_source,
 
   $influxdb_stderr_log                          = $influxdb::params::influxdb_stderr_log,
   $influxdb_stdout_log                          = $influxdb::params::influxdb_stdout_log,

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -7,18 +7,29 @@ class influxdb::server::install {
     path => '/usr/bin:/bin',
   }
 
-  if $influxdb::server::manage_install {
-    if $ensure == 'absent' {
-      $_ensure = $ensure
-    } else {
-        $_ensure = $version
+  case $influxdb::server::install_method {
+    'repo': {
+      if $ensure == 'absent' {
+        $_ensure = $ensure
+      } else {
+          $_ensure = $version
+      }
+
+      class { 'influxdb::repo': } ->
+
+      package { 'influxdb':
+        ensure => $_ensure,
+        tag    => 'influxdb',
+      }
     }
-
-    class { 'influxdb::repo': } ->
-
-    package { 'influxdb':
-      ensure => $_ensure,
-      tag    => 'influxdb',
+    'package': {
+      class { 'influxdb::repo::package':
+        package_source => $influxdb::server::package_source,
+        version        => $influxdb::server::version
+      }
+    }
+    default: {
+      fail { 'unsupported install_method!': }
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -53,6 +53,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"}
+    {"name":"puppetlabs/apt","version_requirement":">=1.8.0 <3.0.0"},
+    {"name":"maestrodev/wget","version_requirement": ">= 1.6.0 <2.0.0"}
   ]
 }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -5,7 +5,7 @@ describe 'influxdb class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfam
   context 'default parameters' do
 
     pp = <<-EOS
-    class { 'influxdb::server': }
+    class { 'influxdb::server':}
     EOS
 
     it 'should work with no errors' do


### PR DESCRIPTION
Because the influxdb guys have a habit of deleting their old debs from the debian repo, i've added the option to install a deb package from a url.

install from the specified url 

```
install_method => 'package', # default is 'repo'
package_source => 'http://my-file-store.com/influx/influx.deb'
```

Default behaviour is unchanged
