### PR TITLE
Change default for http_max_row_limit to 0

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -88,7 +88,7 @@ class influxdb::params {
     'https-certificate'    => '/etc/ssl/influxdb.pem',
     'https-private-key'    => '',
     'shared-sercret'       => '',
-    'max-row-limit'        => 10000,
+    'max-row-limit'        => 0,
     'max-connection-limit' => 0,
     'unix-socket-enabled'  => false,
     'bind-socket'          => '/var/run/influxdb.sock',

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -102,7 +102,7 @@ class { 'influxdb':
               'https-certificate'    => esc_regex('"/etc/ssl/influxdb.pem"'),
               'https-private-key'    => '',
               'shared-sercret'       => '',
-              'max-row-limit'        => 10_000,
+              'max-row-limit'        => 0,
               'max-connection-limit' => 0,
               'unix-socket-enabled'  => false,
               'bind-socket'          => esc_regex('"/var/run/influxdb.sock"')


### PR DESCRIPTION
The defaults from influxdata have changed with version 1.2.1
https://github.com/influxdata/influxdb/blob/master/CHANGELOG.md#v122-2017-03-14

This module should represent this defaults.