### PR TITLE
Add missing logging section to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,15 @@ A hash of data configuration options for `influxdb.conf`
 
 [params.pp](manifests/params.pp#32)
 
+##### `logging_config`
+
+A hash of logging configuration options for `influxdb.conf`
+
+*NOTE*: The default for this hash is what is in 1.5.x of the influx docs
+
+[Influx Logging Options](https://docs.influxdata.com/influxdb/v1.5/administration/config/#logging-settings-logging)
+
+[params.pp](manifests/params.pp#43)
 
 ##### `coordinator_config`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,6 +16,7 @@ class influxdb::config(
   $global_config             = $influxdb::global_config,
   $meta_config               = $influxdb::meta_config,
   $data_config               = $influxdb::data_config,
+  $logging_config            = $influxdb::logging_config,
   $coordinator_config        = $influxdb::coordinator_config,
   $retention_config          = $influxdb::retention_config,
   $shard_precreation_config  = $influxdb::shard_precreation_config,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class influxdb(
   $global_config             = $influxdb::params::global_config,
   $meta_config               = $influxdb::params::meta_config,
   $data_config               = $influxdb::params::data_config,
+  $logging_config            = $influxdb::params::logging_config,
   $coordinator_config        = $influxdb::params::coordinator_config,
   $retention_config          = $influxdb::params::retention_config,
   $shard_precreation_config  = $influxdb::params::shard_precreation_config,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,6 +39,12 @@ class influxdb::params {
     'max-series-per-database'            => 1000000,
     'max-values-per-tag'                 => 100000,
   }
+  
+  $logging_config = {
+    'format'        => 'auto',
+    'level'         => 'warn',
+    'suppress-logo' => false,
+  }
 
   $coordinator_config = {
     'write-timeout'          => '10s',

--- a/templates/influxdb.conf.erb
+++ b/templates/influxdb.conf.erb
@@ -57,6 +57,8 @@
 
 <%= build_section('data', @data_config) %>
 
+<%= build_section('logging', @logging_config) %>
+
 <%= build_section('coordinator', @coordinator_config) %>
 
 <%= build_section('retention', @retention_config) %>


### PR DESCRIPTION
section [logging] is missing from the config file, this results in info level logging that spams journald and hammers the CPUs causing major performance problems.