### PR TITLE
Add InfluxDB providers

### DIFF
--- a/examples/init.pp
+++ b/examples/init.pp
@@ -1,0 +1,22 @@
+class { '::influxdb':
+  manage_repos => true,
+}
+
+influxdb_retention_policy { 'myrp1@mydb1':
+  duration => '1h',
+  default  => false,
+}
+
+influxdb_retention_policy { 'myrp2@mydb1':
+  duration => '20h',
+  default  => true,
+}
+
+influxdb_database { 'mydb1': }
+
+influxdb_database { 'mydb2': }
+
+influxdb_retention_policy { 'myrp1@mydb2':
+  duration    => '4h10m10s',
+  replication => 2,
+}

--- a/lib/puppet/provider/influxdb.rb
+++ b/lib/puppet/provider/influxdb.rb
@@ -1,0 +1,127 @@
+# Copyright (C) 2018 Binero
+#
+# Author: Tobias Urdin <tobias.urdin@binero.se>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+require 'net/http'
+require 'json'
+
+class Puppet::Provider::InfluxDB < Puppet::Provider
+  # @abstract Subclass is expected to implement #base_url
+  # @method base_url
+  #   The base URL to InfluxDB API
+  #
+  #   Normally we don't want to do this but it's
+  #   easier to stub in testing.
+  def self.base_url
+    raise NotImplementedError
+  end
+
+  # @method parse_url
+  #   Parse the base URL and fix the path that will be used for the requests.
+  #   Protected function that can only used by this class and subclasses that
+  #   inherits this class.
+  # @param path
+  #   The path to add to the base URL, must start with a slash
+  #   or URI will throw an exception.
+  # @param query
+  #   Optional parameter if the query parameters that should be added to
+  #   the URL.
+  protected
+  def self.parse_url(path, query=nil)
+    url = URI.parse(base_url)
+    path.prepend('/') unless path[0] == '/'
+    url.path = URI.escape(path)
+    url.query = URI.escape(query) if query
+    url
+  end
+
+  # @method query
+  #   Run a query against the InfluxDB API
+  # @param query
+  #   The query to run
+  def self.query(query)
+    q = "q=#{query}"
+    post('query', q)
+  end
+
+  # @method get
+  #   Perform a GET request
+  # @param path
+  #   The path to perform a GET request against
+  # @param query
+  #   The query to add to the URL
+  # @param data
+  #   The data to send with the request
+  # @param headers
+  #   The headers to send with the request
+  def self.get(path, query=nil, data=nil, headers=nil)
+    perform_request('GET', path, query, data, headers)
+  end
+
+  # @method post
+  #   Perform a POST request.
+  # @param path
+  #   The path to perform a POST request against
+  # @param query
+  #   The query to add to the URL
+  # @param data
+  #   The data to send with the request
+  # @param headers
+  #   The headers to send with the request
+  def self.post(path, query=nil, data=nil, headers=nil)
+    perform_request('POST', path, query, data, headers)
+  end
+
+  # @method perform_request
+  #   Perform a HTTP request.
+  # @param type
+  #   The HTTP request type
+  # @param path
+  #   The path to perform the request against.
+  # @param data
+  #   The data to send with the request
+  # @param headers
+  #   Hash with headers to add to the request
+  private
+  def self.perform_request(type, path, query=nil, data=nil, headers=nil)
+    url = parse_url(path, query)
+    case type.upcase
+    when 'GET'
+      request = Net::HTTP::Get.new(url.request_uri)
+    when 'POST'
+      request = Net::HTTP::Post.new(url.request_uri)
+    else
+      raise Puppet::Error, "Unsupported HTTP request type: #{type}"
+    end
+    request.content_type = 'application/json'
+    request.body = data
+    if headers then
+      headers.each do |key, value|
+        if !value.is_a?(String) then
+          val = value.to_s
+        else
+          val = value
+        end
+
+        request[key] = val
+      end
+    end
+    response = Net::HTTP.start(url.host, url.port,
+                               :use_ssl => url.scheme == 'https') do |http|
+      http.request(request)
+    end
+    response
+  end
+end

--- a/lib/puppet/provider/influxdb_database/influxdb.rb
+++ b/lib/puppet/provider/influxdb_database/influxdb.rb
@@ -59,47 +59,6 @@ Puppet::Type.type(:influxdb_database).provide(:influxdb, :parent => Puppet::Prov
     @instances.any? {|prov| prov.name == resource[:name]}
   end
 
-  # @method databases
-  #   Get all InfluxDB databases and introduce a retry
-  #   because when the service is being deployed for the
-  #   first time and is initializing the SHOW DATABASES
-  #   query will respond without the "values" key in the
-  #   response.
-  #
-  #   If we instead wait for it to initialize and create
-  #   the "_internal" database we'll get the list properly.
-  #
-  #   This effectively allows for InfluxDB to initialize.
-  def self.databases
-    q = 'SHOW DATABASES'
-    retry_count = 1
-    begin
-      response = self.query(q)
-      if response.code.to_i != 200
-        raise Puppet::Error, "Failed to get InfluxDB databases (HTTP response: #{response.code})"
-      end
-      data = JSON.parse(response.body)
-      results = data['results'][0]
-      series = results['series']
-      if !series[0].include?('values')
-        raise Puppet::Error, 'InfluxDB database response did not contain values, service not started or initialized yet'
-      end
-      values = series[0]['values']
-    rescue => e
-      if retry_count <= 30
-        Puppet.debug("InfluxDB database: #{e.message}, retrying in #{retry_count} seconds")
-        retry_count += 1
-        Kernel.sleep 2
-        retry
-      end
-      raise
-    end
-    ret = values.collect do |value|
-      value[0]
-    end
-    ret
-  end
-
   # @method instances
   #   Get all InfluxDB databases and create resources
   def self.instances

--- a/lib/puppet/provider/influxdb_database/influxdb.rb
+++ b/lib/puppet/provider/influxdb_database/influxdb.rb
@@ -1,0 +1,91 @@
+# Copyright (C) 2018 Binero
+#
+# Author: Tobias Urdin <tobias.urdin@binero.se>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+require 'puppet'
+require 'json'
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'influxdb'))
+
+Puppet::Type.type(:influxdb_database).provide(:influxdb, :parent => Puppet::Provider::InfluxDB) do
+  desc "Provider for influxdb_database type"
+
+  defaultfor :kernel => 'Linux'
+
+  # @method base_url
+  #   The base URL used by Puppet::Provider::InfluxDB
+  def self.base_url
+    'http://localhost:8086'
+  end
+
+  # @method create
+  #   Create the InfluxDB database
+  def create
+    q = "CREATE DATABASE #{resource[:name]}"
+    response = self.class.query(q)
+    if response.code.to_i != 200
+      raise Puppet::Error, "Failed to create InfluxDB database: #{resource[:name]} (HTTP response: #{response.code})"
+    end
+  end
+
+  # @method destroy
+  #   Destroy the InfluxDB database
+  def destroy
+    q = "DROP DATABASE #{resource[:name]}"
+    response = self.class.query(q)
+    if response.code.to_i != 200
+      raise Puppet::Error, "Failed to delete InfluxDB database: #{resource[:name]} (HTTP response: #{response.code})"
+    end
+  end
+
+  # @method exists?
+  #   Check if the database exists
+  def exists?
+    unless @instances
+      @instances = self.class.instances
+    end
+    @instances.any? {|prov| prov.name == resource[:name]}
+  end
+
+  # @method instances
+  #   Get all InfluxDB databases and create resources
+  def self.instances
+    q = 'SHOW DATABASES'
+    response = self.query(q)
+    if response.code.to_i != 200
+      raise Puppet::Error, "Failed to get InfluxDB databases (HTTP response: #{response.code})"
+    end
+    data = JSON.parse(response.body)
+    results = data['results'][0]
+    series = results['series']
+    values = series[0]['values']
+    databases = values.collect do |value|
+      database_name = value[0]
+      new(:name => database_name)
+    end
+    databases
+  end
+
+  # @method prefetch
+  #   Associate all the InfluxDB database resource with a resource
+  def self.prefetch(resources)
+    databases = instances
+    resources.keys.each do |name|
+      if provider = databases.find{ |database| database.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+end

--- a/lib/puppet/provider/influxdb_retention_policy/influxdb.rb
+++ b/lib/puppet/provider/influxdb_retention_policy/influxdb.rb
@@ -1,0 +1,200 @@
+# Copyright (C) 2018 Binero
+#
+# Author: Tobias Urdin <tobias.urdin@binero.se>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+require 'puppet'
+require 'json'
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'influxdb'))
+
+Puppet::Type.type(:influxdb_retention_policy).provide(:influxdb, :parent => Puppet::Provider::InfluxDB) do
+  desc "Provider for influxdb_retention_policy type"
+
+  defaultfor :kernel => 'Linux'
+
+  mk_resource_methods
+
+  def initialize(value={})
+    super(value)
+    @property_flush = {}
+  end
+
+  # @method base_url
+  #   The base URL used by Puppet::Provider::InfluxDB
+  def self.base_url
+    'http://localhost:8086'
+  end
+
+  # @method create
+  #   Create the InfluxDB retention policy on the database
+  def create
+    name_split = resource[:name].split('@')
+    rp_name = name_split.first
+    db_name = name_split.last
+    default_str = ''
+    default_str = ' DEFAULT' if resource[:default] == :true
+    q = "CREATE RETENTION POLICY #{rp_name} ON #{db_name} DURATION #{resource[:duration]}s REPLICATION #{resource[:replication]}#{default_str}"
+    response = self.class.query(q)
+    if response.code.to_i != 200
+      raise Puppet::Error, "Failed to create InfluxDB retention policy: #{rp_name} on database #{db_name} (HTTP response: #{response.code})"
+    end
+    data = JSON.parse(response.body)
+    if data.include?('results')
+      result = data['results'][0]
+      if result.include?('error') and result['error'].include?('database not found')
+        fail Puppet::Error, "Failed to create InfluxDB retention policy #{rp_name}: database #{db_name} does not exist"
+      end
+    end
+  end
+
+  # @method destroy
+  #   Destroy the InfluxDB retention policy on the database
+  def destroy
+    name_split = resource[:name].split('@')
+    rp_name = name_split.first
+    db_name = name_split.last
+    if resource[:default] == :true
+      Puppet.warning("Deleting default InfluxDB retention policy #{rp_name} on databse #{db_name}, this database will have no default retention policy")
+    end
+    q = "DROP RETENTION POLICY #{rp_name} ON #{db_name}"
+    response = self.class.query(q)
+    if response.code.to_i != 200
+      raise Puppet::Error, "Failed to delete InfluxDB retention policy: #{rp_name} on database #{db_name} (HTTP response: #{response.code})"
+    end
+  end
+
+  # @method exists?
+  #   Check if the retention policy exist
+  def exists?
+    unless @instances
+      @instances = self.class.instances
+    end
+    @instances.any? {|prov| prov.name == resource[:name]}
+  end
+
+  # @method retention_policies
+  #   Get all InfluxDB retention policies on the database
+  def self.retention_policies(database)
+    q = "SHOW RETENTION POLICIES ON #{database}"
+    response = self.query(q)
+    if response.code.to_i != 200
+      raise Puppet::Error, "Failed to get InfluxDB retention policies for database #{database} (HTTP response: #{response.code})"
+    end
+    data = JSON.parse(response.body)
+    results = data['results'][0]
+    series = results['series']
+    values = series[0]['values']
+    values
+  end
+
+  # @method duration
+  #   Parse a duration to seconds
+  def self.duration_to_seconds(duration)
+    if duration.is_a?(Integer)
+      return duration
+    end
+    measure_to_seconds = {
+      's' => 1,
+      'm' => 60,
+      'h' => (60 * 60),
+      'd' => (60 * 60 * 24),
+      'w' => (60 * 60 * 24 * 7)
+    }
+    seconds = 0
+    duration.scan(/(\d+)(\w)/).each do |value, measure|
+      seconds += value.to_i * measure_to_seconds[measure]
+    end
+    seconds
+  end
+
+  # @method instances
+  #   Get all InfluxDB retention policies and create resources
+  def self.instances
+    dbs = self.databases
+    ret = []
+    dbs.each do |db|
+      rps = self.retention_policies(db) 
+      ret << rps.collect do |rp|
+        default_sym = :false
+        if rp[4].to_s == 'true'
+          default_sym = :true
+        end
+        new(
+          :name        => "#{rp[0]}@#{db}",
+          :duration    => self.duration_to_seconds(rp[1]),
+          :replication => rp[3],
+          :default     => default_sym,
+        )
+      end
+    end
+    ret.flatten
+  end
+
+  # @method prefetch
+  #   Associate all the InfluxDB retention policy resource with a resource
+  def self.prefetch(resources)
+    rps = instances
+    resources.keys.each do |name|
+      if provider = rps.find{ |rp| rp.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  # @method flush
+  #   Flush changed params to InfluxDB
+  def flush
+    unless @property_flush.empty?
+      name_split = resource[:name].split('@')
+      rp_name = name_split.first
+      db_name = name_split.last
+      q = "ALTER RETENTION POLICY #{rp_name} ON #{db_name}"
+
+      if @property_flush[:duration]
+        q << ' DURATION ' << @property_flush[:duration].to_s << 's'
+      else
+        q << ' DURATION ' << resource[:duration].to_s << 's'
+      end
+      if @property_flush[:replication]
+        q << ' REPLICATION ' << @property_flush[:replication].to_s
+      else
+        q << ' REPLICATION ' << resource[:replication].to_s
+      end
+      if @property_flush[:default] == :true or (resource[:default] == :true and !@property_flush.include? :default)
+        q << ' DEFAULT'
+      end
+      response = self.class.query(q)
+      if response.code.to_i != 200
+        raise Puppet::Error, "Failed to flush InfluxDB retention policy: #{rp_name} on database #{db_name} (HTTP response: #{response.code})"
+      end
+    end
+  end
+
+  def duration=(value)
+    new_value = self.class.duration_to_seconds(value)
+    old_value = self.class.duration_to_seconds(@property_hash[:duration])
+    if new_value and old_value and new_value.to_i != old_value.to_i
+      @property_flush[:duration] = value
+    end
+  end
+
+  def replication=(value)
+    @property_flush[:replication] = value
+  end
+
+  def default=(value)
+    @property_flush[:default] = value
+  end
+end

--- a/lib/puppet/type/influxdb_database.rb
+++ b/lib/puppet/type/influxdb_database.rb
@@ -24,6 +24,7 @@ Puppet::Type.newtype(:influxdb_database) do
 
   newparam(:name, :namevar => true) do
     desc "The name of the database."
+    newvalues(/^[\S]+$/)
   end
 
   autorequire(:service) do

--- a/lib/puppet/type/influxdb_database.rb
+++ b/lib/puppet/type/influxdb_database.rb
@@ -1,0 +1,32 @@
+# Copyright (C) 2018 Binero
+#
+# Author: Tobias Urdin <tobias.urdin@binero.se>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+Puppet::Type.newtype(:influxdb_database) do
+  @doc = "Manage database in InfluxDB"
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc "The name of the database."
+  end
+
+  autorequire(:service) do
+    'influxdb'
+  end
+end

--- a/lib/puppet/type/influxdb_retention_policy.rb
+++ b/lib/puppet/type/influxdb_retention_policy.rb
@@ -1,0 +1,106 @@
+# Copyright (C) 2018 Binero
+#
+# Author: Tobias Urdin <tobias.urdin@binero.se>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+Puppet::Type.newtype(:influxdb_retention_policy) do
+  @doc = "Manage retention policy in InfluxDB"
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  def munge_boolean(value)
+    case value
+    when true, "true", :true
+      :true
+    when false, "false", :false
+      :false
+    else
+      Puppet.fail('influxdb_retention_policy: must be boolean')
+    end
+  end
+
+  def munge_integer(value)
+    Integer(value)
+  rescue ArgumentError
+    Puppet.fail('influxdb_retention_policy: must be integer')
+  end
+
+  # TODO: Move this out to puppetx or util and
+  # use it in provider as well.
+  def duration_to_seconds(duration)
+    if duration.is_a?(Integer)
+      return duration
+    end
+    measure_to_seconds = {
+      's' => 1,
+      'm' => 60,
+      'h' => (60 * 60),
+      'd' => (60 * 60 * 24),
+      'w' => (60 * 60 * 24 * 7)
+    }
+    seconds = 0
+    duration.scan(/(\d+)(\w)/).each do |value, measure|
+      seconds += value.to_i * measure_to_seconds[measure]
+    end
+    seconds
+  end
+
+  def munge_duration(resource, value)
+    new_value = resource.duration_to_seconds(value)
+    if new_value < 3600
+      Puppet.fail('influxdb_retention_policy: duration must be atleast 1 hour')
+    end
+    new_value  
+  end
+
+  newparam(:name, :namevar => true) do
+    desc "The name of the retention policy."
+    newvalues(/^\S+\@\S+$/)
+  end
+
+  newproperty(:duration) do
+    desc "The duration to set on the retention policy."
+    newvalues(/^(\d+w)?(\d+d)?(\d+h)?(\d+m)?(\d+s)?$/)
+
+    munge do |value|
+      @resource.munge_duration(@resource, value)
+    end
+  end
+
+  newproperty(:replication) do
+    desc "The number of replicas if cluster."
+    defaultto(1)
+
+    munge do |value|
+      @resource.munge_integer(value)
+    end
+  end
+
+  newproperty(:default, :boolean => true) do
+    desc "Should the retention policy be default on this database."
+    newvalues(:true, :false)
+    defaultto(:false)
+
+    munge do |value|
+      @resource.munge_boolean(value)
+    end
+  end
+
+  autorequire(:influxdb_database) do
+    self[:name].split('@').last
+  end
+end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,7 +39,7 @@ class influxdb::params {
     'max-series-per-database'            => 1000000,
     'max-values-per-tag'                 => 100000,
   }
-  
+
   $logging_config = {
     'format'        => 'auto',
     'level'         => 'warn',

--- a/spec/unit/provider/influxdb_database/influxdb_spec.rb
+++ b/spec/unit/provider/influxdb_database/influxdb_spec.rb
@@ -34,6 +34,12 @@ describe Puppet::Type.type(:influxdb_database).provider(:influxdb) do
     described_class.new(resource)
   end
 
+  describe '#base_url' do
+    it 'should return base url' do
+      expect(provider.class.base_url).to eq('http://localhost:8086')
+    end
+  end
+
   describe '#create' do
     it 'should be successful' do
       response = Net::HTTPResponse.new('1.0', '200', 'test')

--- a/spec/unit/provider/influxdb_database/influxdb_spec.rb
+++ b/spec/unit/provider/influxdb_database/influxdb_spec.rb
@@ -1,0 +1,115 @@
+# Copyright (C) 2018 Binero
+#
+# Author: Tobias Urdin <tobias.urdin@binero.se>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+require 'spec_helper'
+require 'json'
+require 'puppet/provider/influxdb_database/influxdb'
+
+describe Puppet::Type.type(:influxdb_database).provider(:influxdb) do
+  let(:resource_attrs) do
+    {
+      :name   => 'testdb',
+      :ensure => :present,
+    }
+  end
+
+  let(:resource) do
+    Puppet::Type::Influxdb_database.new(resource_attrs)
+  end
+
+  let(:provider) do
+    described_class.new(resource)
+  end
+
+  describe '#create' do
+    it 'should be successful' do
+      response = Net::HTTPResponse.new('1.0', '200', 'test')
+      described_class.expects(:query).with('CREATE DATABASE testdb').returns(response)
+      provider.create
+    end
+
+    it 'should fail' do
+      response = Net::HTTPResponse.new('1.0', '500', 'test')
+      described_class.expects(:query).with('CREATE DATABASE testdb').returns(response)
+      expect { provider.create }.to raise_error(Puppet::Error)
+    end
+  end
+
+  describe '#destroy' do
+    it 'should be successful' do
+      response = Net::HTTPResponse.new('1.0', '200', 'test')
+      described_class.expects(:query).with('DROP DATABASE testdb').returns(response)
+      provider.destroy
+    end
+
+    it 'should fail' do
+      response = Net::HTTPResponse.new('1.0', '500', 'test')
+      described_class.expects(:query).with('DROP DATABASE testdb').returns(response)
+      expect { provider.destroy }.to raise_error(Puppet::Error)
+    end
+  end
+
+  describe '#exists' do
+    it 'should exist' do
+      described_class.expects(:instances).returns([resource])
+      expect(provider.exists?).to be_truthy
+    end
+
+    context 'should not exist' do
+      it 'when no resources' do
+        described_class.expects(:instances).returns([])
+        expect(provider.exists?).to be_falsey
+      end
+
+      it 'when no matching resources' do
+        resource1 = Puppet::Type::Influxdb_database.new({:name => 'db1'})
+        resource2 = Puppet::Type::Influxdb_database.new({:name => 'db2'})
+        described_class.expects(:instances).returns([resource1, resource2])
+        expect(provider.exists?).to be_falsey
+      end
+    end
+  end
+
+  class HttpResponseMock
+    def code
+      '200'
+    end
+
+    def body
+      '{"results":[{"statement_id":0,"series":[{"name":"databases","columns":["name"],"values":[["_internal"],["db1"],["db2"]]}]}]}'
+    end
+  end
+
+  describe '#instances' do
+    it 'should return the instances' do
+      described_class.expects(:query).with('SHOW DATABASES').returns(HttpResponseMock.new)
+      instances = Puppet::Type::Influxdb_database::ProviderInfluxdb.instances
+      expect(instances.count).to eq(3)
+      expect(instances[0].name).to eq('_internal')
+      expect(instances[1].name).to eq('db1')
+      expect(instances[2].name).to eq('db2')
+    end
+  end
+
+  describe '#prefetch' do
+    it 'should associate provider' do
+      described_class.expects(:query).with('SHOW DATABASES').returns(HttpResponseMock.new)
+      resources = {'testdb' => {'ensure' => 'present'}}
+      Puppet::Type::Influxdb_database::ProviderInfluxdb.prefetch(resources)
+      expect(resource.provider).to eq(provider)
+    end
+  end
+end

--- a/spec/unit/provider/influxdb_database/influxdb_spec.rb
+++ b/spec/unit/provider/influxdb_database/influxdb_spec.rb
@@ -107,7 +107,7 @@ describe Puppet::Type.type(:influxdb_database).provider(:influxdb) do
 
   describe '#prefetch' do
     it 'should associate provider' do
-      described_class.expects(:query).with('SHOW DATABASES').returns(HttpResponseMock.new)
+      described_class.expects(:databases).returns(['db1', 'db2'])
       resources = {'testdb' => {'ensure' => 'present'}}
       Puppet::Type::Influxdb_database::ProviderInfluxdb.prefetch(resources)
       expect(resource.provider).to eq(provider)

--- a/spec/unit/provider/influxdb_database/influxdb_spec.rb
+++ b/spec/unit/provider/influxdb_database/influxdb_spec.rb
@@ -83,51 +83,19 @@ describe Puppet::Type.type(:influxdb_database).provider(:influxdb) do
     end
   end
 
-  class HttpResponseMock
-    def code
-      '200'
-    end
-
-    def body
-      '{"results":[{"statement_id":0,"series":[{"name":"databases","columns":["name"],"values":[["_internal"],["db1"],["db2"]]}]}]}'
-    end
-  end
-
-  class HttpResponseMockWithoutValues
-    def code
-      '200'
-    end
-
-    def body
-      '{"results":[{"statement_id":0,"series":[{"name":"databases","columns":["name"]}]}]}'
-    end
-  end
-
   describe '#instances' do
-    it 'should return the instances when response contains values' do
-      described_class.expects(:query).with('SHOW DATABASES').returns(HttpResponseMock.new)
+    it 'should get instances' do
+      described_class.expects(:databases).returns(['db1', 'db2'])
       instances = Puppet::Type::Influxdb_database::ProviderInfluxdb.instances
-      expect(instances.count).to eq(3)
-      expect(instances[0].name).to eq('_internal')
-      expect(instances[1].name).to eq('db1')
-      expect(instances[2].name).to eq('db2')
+      expect(instances.count).to eq(2)
+      expect(instances[0].name).to eq('db1')
+      expect(instances[1].name).to eq('db2')
     end
 
-    it 'should retry and fail' do
-      Kernel.expects(:sleep).returns(true).times(30)
-      described_class.expects(:query).with('SHOW DATABASES').returns(HttpResponseMockWithoutValues.new).times(31)
-      expect { Puppet::Type::Influxdb_database::ProviderInfluxdb.instances }.to raise_error(Puppet::Error)
-    end
-
-    it 'should retry and success' do
-      Kernel.expects(:sleep).returns(true).times(12)
-      described_class.expects(:query).with('SHOW DATABASES').returns(HttpResponseMock.new)
-      described_class.expects(:query).with('SHOW DATABASES').returns(HttpResponseMockWithoutValues.new).times(12)
+    it 'should get no instances' do
+      described_class.expects(:databases).returns([])
       instances = Puppet::Type::Influxdb_database::ProviderInfluxdb.instances
-      expect(instances.count).to eq(3)
-      expect(instances[0].name).to eq('_internal')
-      expect(instances[1].name).to eq('db1')
-      expect(instances[2].name).to eq('db2')
+      expect(instances.count).to eq(0)
     end
   end
 

--- a/spec/unit/provider/influxdb_retention_policy/influxdb_spec.rb
+++ b/spec/unit/provider/influxdb_retention_policy/influxdb_spec.rb
@@ -1,0 +1,241 @@
+# Copyright (C) 2018 Binero
+#
+# Author: Tobias Urdin <tobias.urdin@binero.se>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+require 'spec_helper'
+require 'json'
+require 'puppet/provider/influxdb_retention_policy/influxdb'
+
+describe Puppet::Type.type(:influxdb_retention_policy).provider(:influxdb) do
+  let(:resource_attrs) do
+    {
+      :ensure      => :present,
+      :name        => 'rp@db',
+      :duration    => '1h',
+      :replication => 2,
+      :default     => true,
+    }
+  end
+
+  let(:resource) do
+    Puppet::Type::Influxdb_retention_policy.new(resource_attrs)
+  end
+
+  let(:provider) do
+    described_class.new(resource)
+  end
+
+  describe '#base_url' do
+    it 'should return base url' do
+      expect(provider.class.base_url).to eq('http://localhost:8086')
+    end
+  end
+
+  class HttpPolicyResponseMock
+    def code
+      '200'
+    end
+
+    def body
+      '{"results":[{"statement_id":0,"series":[{"columns":["name","duration","shardGroupDuration","replicaN","default"],"values":[["autogen","0s","168h0m0s",1,false],["rp","1h0m0s","2h0m0s",2,true]]}]}]}'
+    end
+  end
+
+  class HttpResponseMockWithDatabaseNotFound
+    def code
+      '200'
+    end
+
+    def body
+      '{"results":[{"statement_id":0,"error":"database not found: testdb2"}]}'
+    end
+  end
+
+  describe '#create' do
+    it 'should be successful' do
+      described_class.expects(:query).with('CREATE RETENTION POLICY rp ON db DURATION 3600s REPLICATION 2 DEFAULT').returns(HttpPolicyResponseMock.new)
+      provider.create
+    end
+
+    it 'should fail when database not found' do
+      described_class.expects(:query).with('CREATE RETENTION POLICY rp ON db DURATION 3600s REPLICATION 2 DEFAULT').returns(HttpResponseMockWithDatabaseNotFound.new)
+      expect { provider.create }.to raise_error(Puppet::Error)
+    end
+  end
+
+  describe '#destroy' do
+    it 'should be successful' do
+      response = Net::HTTPResponse.new('1.0', '200', '')
+      described_class.expects(:query).with('DROP RETENTION POLICY rp ON db').returns(response)
+      provider.destroy
+    end
+
+    it 'should fail' do
+      response = Net::HTTPResponse.new('1.0', '500', '')
+      described_class.expects(:query).with('DROP RETENTION POLICY rp ON db').returns(response)
+      expect { provider.destroy }.to raise_error(Puppet::Error)
+    end
+  end
+
+  describe '#exists' do
+    it 'should exist' do
+      described_class.expects(:instances).returns([resource])
+      expect(provider.exists?).to be_truthy
+    end
+
+    context 'should not exist' do
+      it 'when no resources' do
+        described_class.expects(:instances).returns([])
+        expect(provider.exists?).to be_falsey
+      end
+
+      it 'when no matching resources' do
+        resource1 = Puppet::Type::Influxdb_retention_policy.new({:name => 'rp1@db1'})
+        resource2 = Puppet::Type::Influxdb_retention_policy.new({:name => 'rp2@db2'})
+        described_class.expects(:instances).returns([resource1, resource2])
+        expect(provider.exists?).to be_falsey
+      end
+    end
+  end
+
+  describe '#retention_policies' do
+    it 'should get rps' do
+      described_class.expects(:query).with('SHOW RETENTION POLICIES ON db').returns(HttpPolicyResponseMock.new)
+      expected = [["autogen","0s","168h0m0s",1,false],["rp","1h0m0s","2h0m0s",2,true]]
+      expect(described_class.retention_policies('db')).to eq(expected)
+    end
+
+    it 'should fail' do
+      response = Net::HTTPResponse.new('1.0', '500', '')
+      described_class.expects(:query).with('SHOW RETENTION POLICIES ON db').returns(response)
+      expect { described_class.retention_policies('db') }.to raise_error(Puppet::Error)
+    end
+  end
+
+  describe '#duration_to_seconds' do
+    it 'should return if integer' do
+      expect(described_class.duration_to_seconds(1)).to eq(1)
+    end
+
+    it 'should compute seconds to seconds' do
+      expect(described_class.duration_to_seconds('2s')).to eq(2)
+    end
+
+    it 'should do a simple compute to seconds' do
+      expect(described_class.duration_to_seconds('1h')).to eq(3600)
+    end
+
+    it 'should do a full compute to seconds' do
+      expect(described_class.duration_to_seconds('1w1d1h1m10s')).to eq(694870)
+    end
+  end
+
+  describe '#instances' do
+    it 'should get instances' do
+      described_class.expects(:databases).returns(['db1', 'db2'])
+      described_class.expects(:retention_policies).with('db1').returns([["autogen","0s","168h0m0s",1,false],["db1rp","2h0m0s","4h0m0s",2,true]])
+      described_class.expects(:retention_policies).with('db2').returns([["autogen","0s","168h0m0s",1,false],["db2rp","1h0m0s","2h0m0s",1,false]])
+      instances = Puppet::Type::Influxdb_retention_policy::ProviderInfluxdb.instances
+      expect(instances.count).to eq(4)
+
+      expect(instances[0].name).to eq('autogen@db1')
+      expect(instances[0].duration).to eq(0)
+      expect(instances[0].replication).to eq(1)
+      expect(instances[0].default).to eq(:false)
+      expect(instances[1].name).to eq('db1rp@db1')
+      expect(instances[1].duration).to eq(7200)
+      expect(instances[1].replication).to eq(2)
+      expect(instances[1].default).to eq(:true)
+
+      expect(instances[2].name).to eq('autogen@db2')
+      expect(instances[2].duration).to eq(0)
+      expect(instances[2].replication).to eq(1)
+      expect(instances[2].default).to eq(:false)
+      expect(instances[3].name).to eq('db2rp@db2')
+      expect(instances[3].duration).to eq(3600)
+      expect(instances[3].replication).to eq(1)
+      expect(instances[3].default).to eq(:false)
+    end
+
+    it 'should get no instances' do
+      described_class.expects(:databases).returns([])
+      instances = Puppet::Type::Influxdb_retention_policy::ProviderInfluxdb.instances
+      expect(instances.count).to eq(0)
+    end
+  end
+
+  describe '#prefetch' do
+    it 'should associate provider' do
+      resource1 = Puppet::Type::Influxdb_retention_policy.new(
+        :name     => 'rp1@db1',
+        :duration => '1h'
+      )
+      resource2 = Puppet::Type::Influxdb_retention_policy.new(
+        :name     => 'rp1@db1',
+        :duration => '1h'
+      )
+      described_class.expects(:instances).returns([resource1, resource2])
+      resources = {'rp@db' => {'ensure' => 'present', 'duration' => '1h'}}
+      Puppet::Type::Influxdb_retention_policy::ProviderInfluxdb.prefetch(resources)
+      expect(resource.provider).to eq(provider)
+    end
+  end
+
+  describe '#flush' do
+    it 'should not flush anything' do
+      described_class.expects(:query).never
+      provider.flush
+    end
+
+    it 'should successfully flush all' do
+      response = Net::HTTPResponse.new('1.0', '200', '')
+      described_class.expects(:query).with('ALTER RETENTION POLICY rp ON db DURATION 36000s REPLICATION 10').returns(response)
+      provider.instance_variable_get('@property_hash')[:duration] = 3600
+      provider.duration = 36000
+      provider.replication = '10'
+      provider.default = :false
+      provider.flush
+    end
+
+    it 'should flush duration' do
+      response = Net::HTTPResponse.new('1.0', '200', '')
+      described_class.expects(:query).with('ALTER RETENTION POLICY rp ON db DURATION 7200s REPLICATION 2 DEFAULT').returns(response)
+      provider.instance_variable_get('@property_hash')[:duration] = 3600
+      provider.duration = 7200
+      provider.flush
+    end
+
+    it 'should not flush if duration not changed' do
+      described_class.expects(:query).never
+      provider.instance_variable_get('@property_hash')[:duration] = 3600
+      provider.duration = 3600
+      provider.flush
+    end
+
+    it 'should flush replication' do
+      response = Net::HTTPResponse.new('1.0', '200', '')
+      described_class.expects(:query).with('ALTER RETENTION POLICY rp ON db DURATION 3600s REPLICATION 30 DEFAULT').returns(response)
+      provider.replication = 30
+      provider.flush
+    end
+
+    it 'should flush default' do
+      response = Net::HTTPResponse.new('1.0', '200', '')
+      described_class.expects(:query).with('ALTER RETENTION POLICY rp ON db DURATION 3600s REPLICATION 2').returns(response)
+      provider.default = :false
+      provider.flush
+    end
+  end
+end

--- a/spec/unit/provider/influxdb_spec.rb
+++ b/spec/unit/provider/influxdb_spec.rb
@@ -57,6 +57,54 @@ describe Puppet::Provider::InfluxDB do
     end
   end
 
+  class HttpResponseMock
+    def code
+      '200'
+    end
+
+    def body
+      '{"results":[{"statement_id":0,"series":[{"name":"databases","columns":["name"],"values":[["_internal"],["db1"],["db2"]]}]}]}'
+    end
+  end
+
+  class HttpResponseMockWithoutValues
+    def code
+      '200'
+    end
+
+    def body
+      '{"results":[{"statement_id":0,"series":[{"name":"databases","columns":["name"]}]}]}'
+    end
+  end
+
+  describe '#databases' do
+    it 'should return the instances when response contains values' do
+      described_class.expects(:query).with('SHOW DATABASES').returns(HttpResponseMock.new)
+      instances = Puppet::Type::Influxdb_database::ProviderInfluxdb.instances
+      expect(instances.count).to eq(3)
+      expect(instances[0].name).to eq('_internal')
+      expect(instances[1].name).to eq('db1')
+      expect(instances[2].name).to eq('db2')
+    end
+
+    it 'should retry and fail' do
+      Kernel.expects(:sleep).returns(true).times(30)
+      described_class.expects(:query).with('SHOW DATABASES').returns(HttpResponseMockWithoutValues.new).times(31)
+      expect { Puppet::Type::Influxdb_database::ProviderInfluxdb.instances }.to raise_error(Puppet::Error)
+    end
+
+    it 'should retry and success' do
+      Kernel.expects(:sleep).returns(true).times(12)
+      described_class.expects(:query).with('SHOW DATABASES').returns(HttpResponseMock.new)
+      described_class.expects(:query).with('SHOW DATABASES').returns(HttpResponseMockWithoutValues.new).times(12)
+      instances = Puppet::Type::Influxdb_database::ProviderInfluxdb.instances
+      expect(instances.count).to eq(3)
+      expect(instances[0].name).to eq('_internal')
+      expect(instances[1].name).to eq('db1')
+      expect(instances[2].name).to eq('db2')
+    end
+  end
+
   describe '#perform_request' do
     before :each do
       Puppet::Provider::InfluxDB.expects(:base_url).returns('http://localhost:8086')

--- a/spec/unit/provider/influxdb_spec.rb
+++ b/spec/unit/provider/influxdb_spec.rb
@@ -1,0 +1,81 @@
+# Copyright (C) 2018 Binero
+#
+# Author: Tobias Urdin <tobias.urdin@binero.se>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+require 'spec_helper'
+require 'puppet/provider/influxdb'
+
+describe Puppet::Provider::InfluxDB do
+  describe '#parse_url' do
+    it 'should parse url' do
+      Puppet::Provider::InfluxDB.expects(:base_url).returns('http://localhost:8086').at_most(4)
+      url1 = described_class.parse_url('first_url')
+      url2 = described_class.parse_url('/second_url')
+      url3 = described_class.parse_url('third_url', 'q=test query')
+      url4 = described_class.parse_url('fourth_url', 'q=test1&w=test2 test3')
+      exp1 = URI::parse('http://localhost:8086/first_url')
+      expect(url1).to eq(exp1)
+      exp2 = URI::parse('http://localhost:8086/second_url')
+      expect(url2).to eq(exp2)
+      exp3 = URI::parse('http://localhost:8086/third_url?q=test%20query')
+      expect(url3).to eq(exp3)
+      exp4 = URI::parse('http://localhost:8086/fourth_url?q=test1&w=test2%20test3')
+      expect(url4).to eq(exp4)
+    end
+  end
+
+  describe '#query' do
+    it 'should do a query' do
+      described_class.expects(:post).with('query', 'q=query here').returns(true)
+      expect(described_class.query('query here')).to be_truthy
+    end
+  end
+
+  describe '#get' do
+    it 'should do a get' do
+      described_class.expects(:perform_request).with('GET', 'query', 'q=test', nil, nil).returns(true)
+      expect(described_class.get('query', 'q=test')).to be_truthy
+    end
+  end
+
+  describe '#post' do
+    it 'should do a post' do
+      described_class.expects(:perform_request).with('POST', 'query', 'q=test', nil, nil).returns(true)
+      expect(described_class.post('query', 'q=test')).to be_truthy
+    end
+  end
+
+  describe '#perform_request' do
+    before :each do
+      Puppet::Provider::InfluxDB.expects(:base_url).returns('http://localhost:8086')
+    end
+
+    it 'should do a default get' do
+      Net::HTTP.expects(:start).returns(true)
+      response = described_class.perform_request('GET', 'path')
+      expect(response).to eq(true)
+    end
+
+    it 'should do a get with query, data and headers' do
+      Net::HTTP.expects(:start).returns(true)
+      response = described_class.perform_request('GET', 'path', 'q=query', 'data', {'my' => 'header'})
+      expect(response).to eq(true)
+    end
+
+    it 'should fail' do
+      expect { described_class.perform_request('what', 'path') }.to raise_error(Puppet::Error)
+    end
+  end  
+end

--- a/spec/unit/type/influxdb_database_spec.rb
+++ b/spec/unit/type/influxdb_database_spec.rb
@@ -28,6 +28,15 @@ describe Puppet::Type.type(:influxdb_database) do
     expect(@influxdb_db_resource[:name]).to eq('testdb')
   end
 
+  it 'should allow numbers in name' do
+    @influxdb_db_resource[:name] = 'mydb1'
+    expect(@influxdb_db_resource[:name]).to eq('mydb1')
+  end
+
+  it 'should not allow invalid names' do
+    expect { @influxdb_db_resource[:name] = 'my invalid name' }.to raise_error(Puppet::ResourceError)
+  end
+
   it 'should have ensure present' do
     @influxdb_db_resource[:ensure] = 'present'
     expect(@influxdb_db_resource[:ensure]).to eq(:present)

--- a/spec/unit/type/influxdb_database_spec.rb
+++ b/spec/unit/type/influxdb_database_spec.rb
@@ -1,0 +1,40 @@
+# Copyright (C) 2018 Binero
+#
+# Author: Tobias Urdin <tobias.urdin@binero.se>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+require 'spec_helper'
+require 'puppet/type/influxdb_database'
+
+describe Puppet::Type.type(:influxdb_database) do
+  before do
+    @influxdb_db_resource = Puppet::Type::type(:influxdb_database).new(
+      :name   => 'testdb',
+    )
+  end
+
+  it 'should have its name set' do
+    expect(@influxdb_db_resource[:name]).to eq('testdb')
+  end
+
+  it 'should have ensure present' do
+    @influxdb_db_resource[:ensure] = 'present'
+    expect(@influxdb_db_resource[:ensure]).to eq(:present)
+  end
+
+  it 'should have ensure absent' do
+    @influxdb_db_resource[:ensure] = 'absent'
+    expect(@influxdb_db_resource[:ensure]).to eq(:absent)
+  end
+end

--- a/spec/unit/type/influxdb_retention_policy_spec.rb
+++ b/spec/unit/type/influxdb_retention_policy_spec.rb
@@ -1,0 +1,118 @@
+# Copyright (C) 2018 Binero
+#
+# Author: Tobias Urdin <tobias.urdin@binero.se>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+require 'spec_helper'
+require 'puppet/type/influxdb_retention_policy'
+
+describe Puppet::Type.type(:influxdb_retention_policy) do
+  before do
+    @influxdb_rp_resource = Puppet::Type::type(:influxdb_retention_policy).new(
+      :name        => 'rp@mydb',
+      :duration    => '1h',
+      :replication => 1,
+      :default     => true,
+    )
+  end
+
+  it 'should have its name set' do
+    expect(@influxdb_rp_resource[:name]).to eq('rp@mydb')
+  end
+
+  it 'should have its name set with numbers' do
+    test_name_rp = Puppet::Type::type(:influxdb_retention_policy).new(
+      :name        => 'rp1@mydb1',
+      :duration    => '1h',
+      :replication => 1,
+    )
+    expect(test_name_rp[:name]).to eq('rp1@mydb1')
+  end
+
+  it 'should fail with invalid name' do
+    expect { Puppet::Type::type(:influxdb_retention_policy).new(
+      :name        => 'invalid',
+      :duration    => '1h',
+      :replication => 1,
+    ) }.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should have ensure present' do
+    @influxdb_rp_resource[:ensure] = 'present'
+    expect(@influxdb_rp_resource[:ensure]).to eq(:present)
+  end
+
+  it 'should have ensure absent' do
+    @influxdb_rp_resource[:ensure] = 'absent'
+    expect(@influxdb_rp_resource[:ensure]).to eq(:absent)
+  end
+
+  it 'should have duration set' do
+    expect(@influxdb_rp_resource[:duration]).to eq(3600)
+  end
+
+  it 'multiple duration measures' do
+    @influxdb_rp_resource[:duration] = '1w1d1h1m10s'
+    expect(@influxdb_rp_resource[:duration]).to eq(694870)
+  end
+
+  it 'fails with invalid duration format' do
+    expect { @influxdb_rp_resource[:duration] = '1h hello 1m world' }.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'fails if duration is below 1 hour' do
+    expect { @influxdb_rp_resource[:duration] = '59m' }.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should have replication set by default' do
+    expect(@influxdb_rp_resource[:replication]).to eq(1)
+  end
+
+  it 'should set replication' do
+    @influxdb_rp_resource[:replication] = 3
+    expect(@influxdb_rp_resource[:replication]).to eq(3)
+  end
+
+  it 'with invalid replication string' do
+    expect { @influxdb_rp_resource[:replication] = 'invalid' }.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'with invalid replication spaces' do
+    expect { @influxdb_rp_resource[:replication] = '1 2' }.to raise_error(Puppet::ResourceError)
+  end
+
+  it 'should have default set to true by default' do
+    expect(@influxdb_rp_resource[:default]).to eq(:true)
+  end
+
+  it 'should have default set to true' do
+     @influxdb_rp_resource[:default] = true
+     expect(@influxdb_rp_resource[:default]).to eq(:true)
+  end
+
+  it 'should have default set to false' do
+    @influxdb_rp_resource[:default] = false
+    expect(@influxdb_rp_resource[:default]).to eq(:false)
+  end
+
+  it 'should have default set to true when using string' do
+    @influxdb_rp_resource[:default] = 'true'
+    expect(@influxdb_rp_resource[:default]).to eq(:true)
+  end
+
+  it 'should have default set to false when using string' do
+    @influxdb_rp_resource[:default] = 'false'
+    expect(@influxdb_rp_resource[:default]).to eq(:false)
+  end
+end


### PR DESCRIPTION
This implements the base InfluxDB provider that can be used by provider resources to
talk to the InfluxDB API and perform actions.

Initial implementation contains the influxdb_database and influxdb_retention policy resources which can be used to manage databases and retention policies in InfluxDB.

The resources must be executed on the same node as InfluxDB is running because it talks to the API over http://localhost:8086.

```
class { '::influxdb':
  manage_repos => true,
}

influxdb_retention_policy { 'myrp1@mydb1':
  duration => '1h',
  default  => false,
}

influxdb_retention_policy { 'myrp2@mydb1':
  duration => '20h',
  default  => true,
}

influxdb_database { 'mydb1': }

influxdb_database { 'mydb2': }

influxdb_retention_policy { 'myrp1@mydb2':
  duration    => '4h10m10s',
  replication => 2,
}
```

All of it should come with pretty decent unit testing, some things could be improved but does
the job for now. Also throwing in a lint fix in params.pp that caused errors.

Best regards
Tobias