### PR TITLE
Update dependencies to work with Puppet v4.x, v5.x, & v6.x.

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,11 +1,7 @@
 fixtures:
-  repositories:
-    apt:
-      repo: 'https://github.com/puppetlabs/puppetlabs-apt'
-      ref:  '2.3.0'
-    stdlib:
-      repo: 'https://github.com/puppetlabs/puppetlabs-stdlib'
-      ref:  '4.12.0'
+  forge_modules:
+    stdlib: "puppetlabs/stdlib"
+    apt: "puppetlabs/apt"
+    yumrepo: "puppetlabs/yumrepo_core"
   symlinks:
     influxdb: "#{source_dir}"
-

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,8 @@ pkg/
 log/
 vendor/bundle
 .bundle
-
+*.iml
+*.ipr
+*.iws
+.idea/
+local/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,23 @@ script: "bundle exec rake test SPEC_OPTS='--format documentation'"
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 2.1.6
-    env: PUPPET_GEM_VERSION="~> 3.8.1"
-  - rvm: 2.1.6
-    env: PUPPET_VERSION="~> 4.0.0"
-  - rvm: 2.3.3
-    env: PUPPET_VERSION="~> 4.0" CHECK=rubocop
+    - rvm: 2.4.5
+      env: PUPPET_VERSION="~> 4.0"
+    - rvm: 2.5.5
+      env: PUPPET_VERSION="~> 4.0"
+    - rvm: 2.6.2
+      env: PUPPET_VERSION="~> 4.0"
+    - rvm: 2.4.5
+      env: PUPPET_VERSION="~> 5.0"
+    - rvm: 2.5.5
+      env: PUPPET_VERSION="~> 5.0"
+    - rvm: 2.6.2
+      env: PUPPET_VERSION="~> 5.0"
+    - rvm: 2.4.5
+      env: PUPPET_VERSION="~> 6.0"
+    - rvm: 2.5.5
+      env: PUPPET_VERSION="~> 6.0"
+    - rvm: 2.6.2
+      env: PUPPET_VERSION="~> 6.0" CHECK=rubocop
 notifications:
   email: dejan@golja.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##2019-??-?? - Release ?.?.?
+###Summary
+- Add support for Puppet v4.x, v5.x, & v6.x.
+
 ##2016-10-24 - Release 4.0.0
 ###Summary
 - Official support for influxdb 1.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -10,13 +10,6 @@ def location_for(place, fake_version = nil)
   end
 end
 
-ruby_ver = RUBY_VERSION.gsub(/\./, "").to_i
-if ruby_ver < 225
-  ENV['BEAKER_VERSION'].nil? ? ENV['BEAKER_VERSION'] = '2.51.0' : nil
-else
-  ENV['BEAKER_VERSION'].nil? ? ENV['BEAKER_VERSION'] = '3.10.0' : nil
-end
-
 group :development, :test do
   gem 'rake',                       require: false
   gem 'rspec',                      require: false
@@ -34,7 +27,7 @@ group :development, :test do
 end
 
 group :system_tests do
-  gem 'beaker',                        *location_for(ENV['BEAKER_VERSION'] || '~> 2.0')
+  gem 'beaker',                        *location_for(ENV['BEAKER_VERSION'] || '~> 3.34')
   gem 'beaker-rspec',                  require: false
   gem 'beaker_spec_helper',            require: false
   gem 'beaker-hiera',                  require: false

--- a/metadata.json
+++ b/metadata.json
@@ -29,15 +29,15 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
-        "7"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04",
-        "14.04"
+        "16.04",
+        "18.04"
       ]
     },
     {
@@ -47,17 +47,17 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 <7.0.0"
     }
   ],
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 1.0.0 <4.13.0"
+      "version_requirement": ">= 1.0.0 <6.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=1.8.0 <3.0.0"
+      "version_requirement": ">=1.8.0 <7.0.0"
     }
   ]
 }

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -2,12 +2,12 @@ HOSTS:
   ubuntu-trusty:
     roles:
       - master
-    platform: ubuntu-14.04-x64
-    image: ubuntu:trusty
+    platform: ubuntu-18.04-x64
+    image: ubuntu:bionic
     hypervisor: docker
     docker_preserve_image: true
+    docker_container_name: "beaker-influxdb-ubuntu-bionic"
     docker_cmd: '["/sbin/init", "/usr/sbin/sshd", "-D"]'
-    docker_container_name: "beaker-influxdb-ubuntu-trusty"
     docker_image_commands:
       # ensure that upstart is booting correctly in the container
       - 'rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget && locale-gen en_US.UTF-8'

--- a/spec/acceptance/nodesets/ubuntu-bionic.yml
+++ b/spec/acceptance/nodesets/ubuntu-bionic.yml
@@ -1,15 +1,13 @@
 HOSTS:
-  ubuntu-precise:
+  ubuntu-trusty:
     roles:
       - master
-    platform: ubuntu-12.04-x64
-    image: ubuntu:precise
+    platform: ubuntu-18.04-x64
+    image: ubuntu:bionic
     hypervisor: docker
     docker_preserve_image: true
-    docker_container_name: "beaker-influxdb-ubuntu-precise"
-    docker_image_commands:
-      - 'apt-get install -y net-tools'
-    docker_cmd: '["/sbin/init"]'
+    docker_container_name: "beaker-influxdb-ubuntu-bionic"
+    docker_cmd: '["/sbin/init", "/usr/sbin/sshd", "-D"]'
     docker_image_commands:
       # ensure that upstart is booting correctly in the container
       - 'rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget && locale-gen en_US.UTF-8'

--- a/spec/acceptance/nodesets/ubuntu-xenial.yml
+++ b/spec/acceptance/nodesets/ubuntu-xenial.yml
@@ -2,12 +2,12 @@ HOSTS:
   ubuntu-trusty:
     roles:
       - master
-    platform: ubuntu-14.04-x64
-    image: ubuntu:trusty
+    platform: ubuntu-16.04-x64
+    image: ubuntu:xenial
     hypervisor: docker
     docker_preserve_image: true
-    docker_container_name: "beaker-influxdb-ubuntu-trusty"
-    docker_cmd: '["/sbin/init"]'
+    docker_container_name: "beaker-influxdb-ubuntu-xenial"
+    docker_cmd: '["/sbin/init", "/usr/sbin/sshd", "-D"]'
     docker_image_commands:
       # ensure that upstart is booting correctly in the container
       - 'rm /usr/sbin/policy-rc.d && rm /sbin/initctl && dpkg-divert --rename --remove /sbin/initctl && apt-get update && apt-get install -y net-tools wget && locale-gen en_US.UTF-8'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -38,8 +38,6 @@ RSpec.configure do |c|
       on host, puppet('resource package git ensure=installed')
       on host, puppet('resource package net-tools ensure=installed')
       on host, puppet('resource package iproute ensure=installed')
-      # on host, puppet('module install puppetlabs-stdlib --version 4.12.0'), { :acceptable_exit_codes => [0,1] }
-      # on host, puppet('module install puppetlabs-apt    --version 2.3.0'), { :acceptable_exit_codes => [0,1] }
 
       scp_to(host, "#{proj_root}/spec/fixtures/test_facter.sh", '/usr/bin/test_facter.sh')
       scp_to(host, "#{proj_root}/spec/fixtures/test_facter.rb", '/usr/bin/test_facter.rb')


### PR DESCRIPTION
This updates the dependencies identified in issue #74 as well as obsoletes PR's #65 and #70.
Updated the Travis configuration to removed the EOL'd Ruby versions.
Added a place holder version to the change log for work currently in progress.